### PR TITLE
linting of code and added linter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,23 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es2021": true,
+        "node": true
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended"
+    ],
+    "overrides": [
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaVersion": "latest"
+    },
+    "plugins": [
+        "@typescript-eslint"
+    ],
+    "rules": {
+    }
+}

--- a/__tests__/angora-test1.ts
+++ b/__tests__/angora-test1.ts
@@ -6,11 +6,12 @@ const {
   toKebabCase,
   generateProperties,
   formatValue,
-} = require("../");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+} = require('../');
 
-test("generateAngularComponent should generate a valid component", () => {
+test('generateAngularComponent should generate a valid component', () => {
   class TestClass {
-    template = "<div>Hello World</div>";
+    template = '<div>Hello World</div>';
     testMethod() {
       return true;
     }
@@ -18,57 +19,57 @@ test("generateAngularComponent should generate a valid component", () => {
 
   const componentCode = generateAngularComponent(TestClass);
   expect(componentCode).toContain(
-    "export class TestClass implements ControlValueAccessor"
+    'export class TestClass implements ControlValueAccessor'
   );
 });
 
-test("generateMethods should generate method string", () => {
-  const methods = ["", "testMethod"];
+test('generateMethods should generate method string', () => {
+  const methods = ['', 'testMethod'];
   const instance = {
     testMethod() { return true; },
   };
 
   const methodString = generateMethods(instance, methods);
-  expect(methodString).toContain(`testMethod() { return true; }`);
+  expect(methodString).toContain('testMethod() { return true; }');
 });
 
-test("typescriptIfy should add : any to function parameters", () => {
-  const functionCode = "(param1, param2)";
-  expect(typescriptIfy(functionCode)).toBe("(param1: any, param2: any)");
+test('typescriptIfy should add : any to function parameters', () => {
+  const functionCode = '(param1, param2)';
+  expect(typescriptIfy(functionCode)).toBe('(param1: any, param2: any)');
 });
 
-test("generateTemplate should wrap HTML in backticks", () => {
-  const html = "<div>Hello World</div>";
+test('generateTemplate should wrap HTML in backticks', () => {
+  const html = '<div>Hello World</div>';
   expect(generateTemplate(html)).toBe(`\n    ${html}\n  `);
 });
 
-test("toKebabCase should convert CamelCase to kebab-case", () => {
-  const str = "CamelCase";
-  expect(toKebabCase(str)).toBe("camel-case");
+test('toKebabCase should convert CamelCase to kebab-case', () => {
+  const str = 'CamelCase';
+  expect(toKebabCase(str)).toBe('camel-case');
 });
 
-test("generateProperties should generate properties string", () => {
+test('generateProperties should generate properties string', () => {
   const instance = {
-    template: `<div>Hello World</div>`,
-    testProp: "testValue",
+    template: '<div>Hello World</div>',
+    testProp: 'testValue',
     onChange: (value: any) => {},
   };
 
   const propertiesString = generateProperties(instance);
-  expect(propertiesString).toContain("testProp = 'testValue'");
-  expect(propertiesString).toContain("onChange = (value: any) => { }");
+  expect(propertiesString).toContain('testProp = \'testValue\'');
+  expect(propertiesString).toContain('onChange = (value: any) => { }');
 });
 
-test("formatValue should format value correctly", () => {
-  expect(formatValue("test")).toBe("'test'");
-  expect(formatValue(true)).toBe("true");
+test('formatValue should format value correctly', () => {
+  expect(formatValue('test')).toBe('\'test\'');
+  expect(formatValue(true)).toBe('true');
   expect(formatValue(123)).toBe(123);
 });
 
-jest.mock("fs", () => ({
+jest.mock('fs', () => ({
   writeFileSync: jest.fn(),
 }));
 
-jest.mock("path", () => ({
+jest.mock('path', () => ({
   resolve: jest.fn(),
 }));

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.21.5",
     "@types/jest": "^29.5.2",
+    "@typescript-eslint/eslint-plugin": "^5.59.9",
+    "@typescript-eslint/parser": "^5.59.9",
+    "eslint": "^8.42.0",
     "loader-utils": "^3.2.1",
     "ts-jest": "^29.1.0"
   }


### PR DESCRIPTION
Setted up linter and review a bit of the code that was flagged by linter. Linter really likes es6 import over Commonjs require. Will keep this in mind when reviewing and test to see if es6 import will affect npm package functionality if we decide to convert to es6.